### PR TITLE
ci(github): add workflow build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: build
+on: [push, pull_request]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Ren'Py
+        uses: remarkablegames/setup-renpy@v1
+        id: renpy
+        with:
+          web: true
+
+      - name: Web build
+        run: renpy-cli ${{ steps.renpy.outputs.launcher }} web_build . --destination dist
+
+      - name: Upload artifacts
+        if: github.ref_name == 'master'
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-artifact
+          path: dist
+
+      - name: Deploy
+        if: github.ref_name == 'master'
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: dist


### PR DESCRIPTION
## What is the motivation for this pull request?

ci(github): add workflow build.yml

https://www.renpy.org/doc/html/web.html

https://www.renpy.org/doc/html/cli.html#web-build

## What is the current behavior?

No way to build for web

## What is the new behavior?

Builds for web and deploys to `gh-pages`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation